### PR TITLE
Override base_url

### DIFF
--- a/lib/athena_health/client.rb
+++ b/lib/athena_health/client.rb
@@ -1,11 +1,12 @@
 module AthenaHealth
   class Client
-    def initialize(version:, key:, secret:, token: nil)
+    def initialize(version:, key:, secret:, token: nil, base_url: AthenaHealth::Connection::BASE_URL)
       @api = AthenaHealth::Connection.new(
         version: version,
         key: key,
         secret: secret,
         token: token,
+        base_url: base_url,
       )
     end
 

--- a/spec/support/client.rb
+++ b/spec/support/client.rb
@@ -3,7 +3,8 @@ def client_attributes
     version: 'preview1',
     key: 'test_key',
     secret: 'test_secret',
-    token: 'test_access_token'
+    token: 'test_access_token',
+    base_url: AthenaHealth::Connection::BASE_URL,
   }
 end
 


### PR DESCRIPTION
## Setup

Update the gem file to the new branch and bundle.
## Positive Test Case

Test overriding the base URL.
1. Run the command.
   
   ``` ruby
   client = AthenaHealth::Client.new(
     key: 'athena_key',
     secret: 'athena_secret',
     token: 'token',
     version: 'v1',
     base_url: 'https://dev111.athenahealth.com',
   )
   ```
2. The code should produce a client with the base url `https://dev111.athenahealth.com`.
## Negative Test Case
1. Run the command.
   
   ``` ruby
   client = AthenaHealth::Client.new(
     key: 'athena_key',
     secret: 'athena_secret',
     token: 'token',
     version: 'v1',
   )
   ```
2. Without the base_url it should default to `https://api.athenahealth.com`.
